### PR TITLE
fix: don't unref worker before terminate in kills() — fixes Windows Node process hang (#44)

### DIFF
--- a/src/runtime/pool.ts
+++ b/src/runtime/pool.ts
@@ -947,8 +947,8 @@ const spawnProcessWorker = (
 
 const terminateWorkerQuietly = (worker: SpawnedWorker): void => {
   try {
-    // Runaway worker termination can be slow or stuck on some runtimes; once the
-    // pool is closing it must not keep the host process alive.
+    // Used for crashed workers whose state is unknown. Unref first so a stuck
+    // or runaway worker does not block the host process from exiting.
     worker.unref?.();
     void Promise.resolve(worker.terminate()).catch(() => {});
   } catch {
@@ -1400,7 +1400,14 @@ export const spawnWorkerContext = ({
     call,
     kills: async () => {
       markWorkerClosed("Thread closed");
-      terminateWorkerQuietly(worker);
+      // Do NOT unref() before terminate(). On Windows, unref() + terminate()
+      // leaves the process hanging for ~105 s because terminate() internally
+      // re-refs the worker handle, negating the unref. Without the unref call
+      // the ref'd worker keeps the process alive only until the OS finishes
+      // the termination (milliseconds for idle workers). The unref fallback
+      // in terminateWorkerQuietly() is reserved for crashed/runaway workers
+      // where we must not block the host process.
+      void Promise.resolve(worker.terminate()).catch(() => {});
     },
     lock,
     processSharedMemoryBackings: processSharedMemory?.backings,


### PR DESCRIPTION
## Summary

- Removes `worker.unref()` from the normal `kills()` shutdown path in `src/runtime/pool.ts`
- On Windows + Node, calling `unref()` immediately before `terminate()` causes the process to hang for ~105 s after tests complete — `terminate()` internally re-refs the worker handle, negating the `unref()`
- Without `unref()`, the ref'd worker handle keeps the process alive only until `terminate()` completes and the `exit` event fires (milliseconds for idle/spinning workers)
- `terminateWorkerQuietly()` — used for crashed/runaway workers — retains `unref()` so a stuck worker cannot block the host process indefinitely

## What changed

**`src/runtime/pool.ts` — `kills()`** (the normal pool-shutdown path):

```diff
- terminateWorkerQuietly(worker);   // called unref() + terminate()
+ void Promise.resolve(worker.terminate()).catch(() => {});  // no unref()
```

**`terminateWorkerQuietly`** comment updated to clarify it is now only for crashed/runaway workers.

## Test plan

- [x] `npm run test:node` on Windows: 227 pass, 6 skip (4 native-addon + 1 Windows hard-timeout + 1 futex), 3 fail (pre-existing native-addon build missing)
- [x] Suite completes in ~13 s — no process hang after last test
- [x] Hard-timeout skip (`Windows Node can keep the terminated runaway worker alive`) remains in place
- [x] All previously-passing tests still pass; no new failures introduced

Fixes #44

🤖 Generated with [Claude Code](https://claude.ai/claude-code)