### PR TITLE
Revert "fix: don't unref worker before terminate in kills() — fixes Windows Node process hang (#44)"

### DIFF
--- a/src/runtime/pool.ts
+++ b/src/runtime/pool.ts
@@ -947,8 +947,8 @@ const spawnProcessWorker = (
 
 const terminateWorkerQuietly = (worker: SpawnedWorker): void => {
   try {
-    // Used for crashed workers whose state is unknown. Unref first so a stuck
-    // or runaway worker does not block the host process from exiting.
+    // Runaway worker termination can be slow or stuck on some runtimes; once the
+    // pool is closing it must not keep the host process alive.
     worker.unref?.();
     void Promise.resolve(worker.terminate()).catch(() => {});
   } catch {
@@ -1400,14 +1400,7 @@ export const spawnWorkerContext = ({
     call,
     kills: async () => {
       markWorkerClosed("Thread closed");
-      // Do NOT unref() before terminate(). On Windows, unref() + terminate()
-      // leaves the process hanging for ~105 s because terminate() internally
-      // re-refs the worker handle, negating the unref. Without the unref call
-      // the ref'd worker keeps the process alive only until the OS finishes
-      // the termination (milliseconds for idle workers). The unref fallback
-      // in terminateWorkerQuietly() is reserved for crashed/runaway workers
-      // where we must not block the host process.
-      void Promise.resolve(worker.terminate()).catch(() => {});
+      terminateWorkerQuietly(worker);
     },
     lock,
     processSharedMemoryBackings: processSharedMemory?.backings,


### PR DESCRIPTION
Reverts mimiMonads/knitting#45 , shagging on the https://github.com/mimiMonads/knitting/actions/runs/26330427049/job/77515488296 , at this point I believe is related with actions itself, I don't have a windows environment to test it